### PR TITLE
pyPLUTO now works with datafiles created by PLUTO v4.1

### DIFF
--- a/pyPLUTO.py
+++ b/pyPLUTO.py
@@ -154,48 +154,48 @@ class pload(object):
 	dx2 - Array dx2\n
 	dx3 - Array dx3\n
 	"""
-	    
-        fname_g = self.wdir+"grid.out"
-        f_grid=open(fname_g)
-        lnum_g = len(f_grid.readlines())
-        # have to make smart code that does pattern matching to find values of n below
-        #####
-        n1 = linecache.getline(fname_g,10)
-        n2 = linecache.getline(fname_g,int(n1)+11)
-        n3 = linecache.getline(fname_g,int(n1)+int(n2)+12)
-        x1=[]
-        x2=[]
-        x3=[]
-        dx1=[]
-        dx2=[]
-        dx3=[]
-        for i in range(2,int(n1)+2):
-            A = linecache.getline(fname_g,i).split()
-            x1.append(float(A[2]))
-            dx1.append(float(A[4]))
-        
-        x1 = np.asarray(x1)
-        dx1 = np.asarray(dx1)
+	fname_g = self.wdir+"grid.out"
+	f_grid= open(fname_g)
+	lnum_g = len(f_grid.readlines())
+	# have to make smart code that does pattern matching to find values of n below
+	#####
+	n1 = linecache.getline(fname_g,10)
+	n2 = linecache.getline(fname_g,int(n1)+11)
+	n3 = linecache.getline(fname_g,int(n1)+int(n2)+12)
+	x1=[]
+	x2=[]
+	x3=[]
+	dx1=[]
+	dx2=[]
+	dx3=[]
 
-        for j in range(3+int(n1),int(n1)+int(n2)+3):
-            B = linecache.getline(fname_g,j).split()
-            x2.append(float(B[2]))
-            dx2.append(float(B[4]))
-        
-        x2 = np.asarray(x2)
-        dx2 = np.asarray(dx2)
+	for i in range(11,int(n1)+10):
+		A = linecache.getline(fname_g,i).split()
+		x1.append(float(A[1]))
+		dx1.append(float(A[2]))
 
-        for k in range(4+int(n1)+int(n2),lnum_g+1):
-            C = linecache.getline(fname_g,k).split()
-            x3.append(float(C[2]))
-            dx3.append(float(C[4]))
+	x1 = np.asarray(x1)
+	dx1 = np.asarray(dx1)
 
-        x3 = np.asarray(x3)
-        dx3 = np.asarray(dx3)
+	for j in range(12+int(n1),int(n1)+int(n2)+11):
+	    B = linecache.getline(fname_g,j).split()
+	    x2.append(float(B[1]))
+	    dx2.append(float(B[2]))
+	 
+	x2 = np.asarray(x2)
+	dx2 = np.asarray(dx2)
 
-        f_grid.close()
-	
-        grid_dict={'n1':int(n1),'n2':int(n2),'n3':int(n3),'x1':x1,'x2':x2,'x3':x3,'dx1':dx1,'dx2':dx2,'dx3':dx3}
+	for k in range(13+int(n1)+int(n2),lnum_g+1):
+	    C = linecache.getline(fname_g,k).split()
+	    x3.append(float(C[1]))
+	    dx3.append(float(C[2]))
+
+	x3 = np.asarray(x3)
+	dx3 = np.asarray(dx3)
+
+	f_grid.close()
+	 
+	grid_dict={'n1':int(n1),'n2':int(n2),'n3':int(n3),'x1':x1,'x2':x2,'x3':x3,'dx1':dx1,'dx2':dx2,'dx3':dx3}
 
 	return grid_dict
 

--- a/pyPLUTO.py
+++ b/pyPLUTO.py
@@ -176,7 +176,7 @@ class pload(object):
 	dx2=[]
 	dx3=[]
 
-	for i in range(11,n1+10):
+	for i in range(ndim+9,n1+ndim+8):
 		A = linecache.getline(fname_g,i).split()
 		x1.append(float(A[1]))
 		dx1.append(float(A[2]))
@@ -184,7 +184,7 @@ class pload(object):
 	x1 = np.asarray(x1)
 	dx1 = np.asarray(dx1)
 
-	for j in range(12+n1,n1+n2+11):
+	for j in range(n1+ndim+10,n1+n2+ndim+9):
 	    B = linecache.getline(fname_g,j).split()
 	    x2.append(float(B[1]))
 	    dx2.append(float(B[2]))
@@ -192,7 +192,7 @@ class pload(object):
 	x2 = np.asarray(x2)
 	dx2 = np.asarray(dx2)
 
-	for k in range(13+n1+n2,lnum_g+1):
+	for k in range(n1+n2+ndim+11,lnum_g+1):
 	    C = linecache.getline(fname_g,k).split()
 	    x3.append(float(C[1]))
 	    dx3.append(float(C[2]))

--- a/pyPLUTO.py
+++ b/pyPLUTO.py
@@ -158,9 +158,11 @@ class pload(object):
         fname_g = self.wdir+"grid.out"
         f_grid=open(fname_g)
         lnum_g = len(f_grid.readlines())
-        n1 = linecache.getline(fname_g,1)
-        n2 = linecache.getline(fname_g,int(n1)+2)
-        n3 = linecache.getline(fname_g,int(n1)+int(n2)+3)
+        # have to make smart code that does pattern matching to find values of n below
+        #####
+        n1 = linecache.getline(fname_g,10)
+        n2 = linecache.getline(fname_g,int(n1)+11)
+        n3 = linecache.getline(fname_g,int(n1)+int(n2)+12)
         x1=[]
         x2=[]
         x3=[]

--- a/pyPLUTO.py
+++ b/pyPLUTO.py
@@ -157,11 +157,18 @@ class pload(object):
 	fname_g = self.wdir+"grid.out"
 	f_grid= open(fname_g)
 	lnum_g = len(f_grid.readlines())
-	# have to make smart code that does pattern matching to find values of n below
-	#####
-	n1 = linecache.getline(fname_g,10)
-	n2 = linecache.getline(fname_g,int(n1)+11)
-	n3 = linecache.getline(fname_g,int(n1)+int(n2)+12)
+
+	# figure out number of dimensions of the problem
+	ndim=linecache.getline(fname_g,5).split()
+	ndim=int(ndim[2])
+
+	# number of points for each coordinate
+	n1 = linecache.getline(fname_g,8+ndim)
+	n1 = int(n1)
+	n2 = linecache.getline(fname_g,9+ndim+n1)
+	n2 = int(n2)
+	n3 = linecache.getline(fname_g,10+ndim+n1+n2)
+	n3 = int(n3)
 	x1=[]
 	x2=[]
 	x3=[]
@@ -169,7 +176,7 @@ class pload(object):
 	dx2=[]
 	dx3=[]
 
-	for i in range(11,int(n1)+10):
+	for i in range(11,n1+10):
 		A = linecache.getline(fname_g,i).split()
 		x1.append(float(A[1]))
 		dx1.append(float(A[2]))
@@ -177,7 +184,7 @@ class pload(object):
 	x1 = np.asarray(x1)
 	dx1 = np.asarray(dx1)
 
-	for j in range(12+int(n1),int(n1)+int(n2)+11):
+	for j in range(12+n1,n1+n2+11):
 	    B = linecache.getline(fname_g,j).split()
 	    x2.append(float(B[1]))
 	    dx2.append(float(B[2]))
@@ -185,7 +192,7 @@ class pload(object):
 	x2 = np.asarray(x2)
 	dx2 = np.asarray(dx2)
 
-	for k in range(13+int(n1)+int(n2),lnum_g+1):
+	for k in range(13+n1+n2,lnum_g+1):
 	    C = linecache.getline(fname_g,k).split()
 	    x3.append(float(C[1]))
 	    dx3.append(float(C[2]))
@@ -195,7 +202,7 @@ class pload(object):
 
 	f_grid.close()
 	 
-	grid_dict={'n1':int(n1),'n2':int(n2),'n3':int(n3),'x1':x1,'x2':x2,'x3':x3,'dx1':dx1,'dx2':dx2,'dx3':dx3}
+	grid_dict={'n1':n1,'n2':n2,'n3':n3,'x1':x1,'x2':x2,'x3':x3,'dx1':dx1,'dx2':dx2,'dx3':dx3}
 
 	return grid_dict
 


### PR DESCRIPTION
pyplut.pload.grid was not able to read correctly the output of PLUTO v4.1. It got confused when reading grid.out because of the new format of the header. I fixed the grid method and now it handles the new format of grid.out for an arbitrary number of dimensions.

Tested for 1 and 2 dimensions.
